### PR TITLE
Add Dependabot auto-merge workflow and configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"
+    # Allow up to 10 open pull requests for npm dependencies
+    open-pull-requests-limit: 10
+    # Specify labels for npm pull requests
+    labels:
+      - "dependencies"
+      - "npm"
+    # Set reviewers
+    reviewers:
+      - "pavlotsyhanok"
+    # Group all updates together
+    groups:
+      dev-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Allow up to 5 open pull requests for GitHub Actions
+    open-pull-requests-limit: 5
+    # Specify labels for GitHub Actions pull requests
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,46 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot-auto-merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Run tests
+        run: npm test
+
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Auto-merge Dependabot PRs
+        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
+        run: |
+          gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
This PR adds a GitHub Actions workflow to automatically merge Dependabot pull requests when tests are passing.

## Changes
- Added `.github/workflows/dependabot-auto-merge.yml` to automatically merge Dependabot PRs when tests pass
- Added `.github/dependabot.yml` to configure Dependabot settings for the repository

## Features
- Automatically merges Dependabot PRs for minor and patch updates
- Skips major version updates which might contain breaking changes
- Runs tests before merging to ensure code quality
- Groups minor and patch updates to reduce PR noise
- Configures weekly checks for npm dependencies and GitHub Actions

## Benefits
- Reduces maintenance overhead for dependency updates
- Ensures dependencies are kept up-to-date with security patches
- Maintains code quality by running tests before merging
- Provides clear labeling and organization of dependency updates

## Testing
The workflow will run automatically on Dependabot pull requests. No manual testing is required.

## Additional Notes
- The workflow uses the GitHub CLI to merge PRs
- Dependabot is configured to create a maximum of 10 open PRs for npm dependencies and 5 for GitHub Actions
- All PRs will be labeled with "dependencies" and either "npm" or "github-actions" for easy filtering